### PR TITLE
fix: apiKey 컬럼 Length 속성 변경 (255 -> 1024)

### DIFF
--- a/src/main/java/org/bob/siungongsi/common/domain/ApiKeyStoreEntity.java
+++ b/src/main/java/org/bob/siungongsi/common/domain/ApiKeyStoreEntity.java
@@ -1,5 +1,6 @@
 package org.bob.siungongsi.common.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,6 +19,7 @@ public class ApiKeyStoreEntity extends ModifiableEntity {
 
   private String keyName;
 
+  @Column(name = "api_key", length = 1024)
   private String apiKey;
 
   public ApiKeyStoreEntity() {}


### PR DESCRIPTION
### Description

실제 API KEY 는 255 자를 넘어 오류가 발생했습니다.
<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #3

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. apiKey length 변경 255 -> 1024


### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

