### PR TITLE
API authController 테스트 작성

### DIFF
--- a/src/test/java/org/bob/siungongsi/api/controller/AuthControllerTest.java
+++ b/src/test/java/org/bob/siungongsi/api/controller/AuthControllerTest.java
@@ -1,0 +1,254 @@
+package org.bob.siungongsi.api.controller;
+
+import static org.bob.siungongsi.fixture.AuthFixture.INVALID_JWT_TOKEN;
+import static org.bob.siungongsi.fixture.AuthFixture.TEST_BEARER_TOKEN;
+import static org.bob.siungongsi.fixture.AuthFixture.TEST_JWT_TOKEN;
+import static org.bob.siungongsi.fixture.AuthFixture.createExistingUserLoginResponse;
+import static org.bob.siungongsi.fixture.AuthFixture.createNewUserLoginResponse;
+import static org.bob.siungongsi.fixture.AuthFixture.createValidRegisterRequest;
+import static org.bob.siungongsi.fixture.TermFixture.createAllTermsResponses;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.bob.siungongsi.api.config.SecurityConfigForApi;
+import org.bob.siungongsi.api.controller.dto.AuthRequest;
+import org.bob.siungongsi.api.controller.dto.AuthResponse;
+import org.bob.siungongsi.api.controller.dto.TermsResponse;
+import org.bob.siungongsi.api.service.AuthService;
+import org.bob.siungongsi.common.dto.ApiResponseCode;
+import org.bob.siungongsi.common.exception.CustomException;
+import org.bob.siungongsi.common.exception.GlobalExceptionHandler;
+import org.bob.siungongsi.testhelper.config.SecurityConfigBeansForTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ActiveProfiles("test")
+@Import({SecurityConfigForApi.class, SecurityConfigBeansForTest.class, GlobalExceptionHandler.class})
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private AuthService authService;
+
+  /** registerUser */
+  @Test
+  @DisplayName("회원가입 시 JWT 토큰을 반환한다")
+  void whenRegister_thenReturnsJwtToken() throws Exception {
+    // given
+    AuthRequest.RegisterRequest request = createValidRegisterRequest();
+    when(authService.register(any(AuthRequest.RegisterRequest.class), eq(TEST_BEARER_TOKEN)))
+        .thenReturn(TEST_JWT_TOKEN);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/v1/auth/register")
+                .header("Authorization", TEST_BEARER_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_REGISTER_SUCCESS.getCode()))
+        .andExpect(jsonPath("$.data").value(TEST_JWT_TOKEN));
+  }
+
+  @Test
+  @DisplayName("이미 존재하는 사용자로 회원가입 시 409 Conflict를 반환한다")
+  void whenRegisterExistingUser_thenReturnsConflict() throws Exception {
+    // given
+    AuthRequest.RegisterRequest request = createValidRegisterRequest();
+    when(authService.register(any(AuthRequest.RegisterRequest.class), eq(TEST_BEARER_TOKEN)))
+        .thenThrow(new CustomException(ApiResponseCode.AUTH_USER_ALREADY_EXISTS));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/v1/auth/register")
+                .header("Authorization", TEST_BEARER_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_USER_ALREADY_EXISTS.getCode()));
+  }
+
+  @Test
+  @DisplayName("필수 약관 미동의 시 403 Forbidden을 반환한다")
+  void whenRegisterWithoutRequiredTerms_thenReturnsForbidden() throws Exception {
+    // given
+    AuthRequest.RegisterRequest request = createValidRegisterRequest();
+    when(authService.register(any(AuthRequest.RegisterRequest.class), eq(TEST_BEARER_TOKEN)))
+        .thenThrow(new CustomException(ApiResponseCode.AUTH_REQUIRED_TERMS_NOT_AGREED));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/v1/auth/register")
+                .header("Authorization", TEST_BEARER_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            jsonPath("$.code").value(ApiResponseCode.AUTH_REQUIRED_TERMS_NOT_AGREED.getCode()));
+  }
+
+  /** loginUser */
+  @Test
+  @DisplayName("기존 사용자 로그인 시 JWT 토큰을 반환한다")
+  void whenLoginExistingUser_thenReturnsJwtToken() throws Exception {
+    // given
+    AuthResponse.LoginSuccessResponse loginResponse = createExistingUserLoginResponse();
+    when(authService.login(TEST_BEARER_TOKEN)).thenReturn(loginResponse);
+
+    // when & then
+    mockMvc
+        .perform(post("/v1/auth/login").header("Authorization", TEST_BEARER_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_LOGIN_SUCCESS.getCode()))
+        .andExpect(jsonPath("$.data.accessToken").value(TEST_JWT_TOKEN))
+        .andExpect(jsonPath("$.data.isUser").value(true));
+  }
+
+  @Test
+  @DisplayName("신규 사용자 로그인 시 isUser가 false를 반환한다")
+  void whenLoginNewUser_thenReturnsIsUserFalse() throws Exception {
+    // given
+    AuthResponse.LoginSuccessResponse loginResponse = createNewUserLoginResponse();
+    when(authService.login(TEST_BEARER_TOKEN)).thenReturn(loginResponse);
+
+    // when & then
+    mockMvc
+        .perform(post("/v1/auth/login").header("Authorization", TEST_BEARER_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_LOGIN_SUCCESS.getCode()))
+        .andExpect(jsonPath("$.data.accessToken").isEmpty())
+        .andExpect(jsonPath("$.data.isUser").value(false));
+
+    verify(authService).login(TEST_BEARER_TOKEN);
+  }
+
+  /** getTerms */
+  @Test
+  @DisplayName("약관 조회 시 약관 목록을 반환한다")
+  void whenGetTerms_thenReturnsTermsList() throws Exception {
+    // given
+    List<TermsResponse> termsResponses = createAllTermsResponses();
+    when(authService.getTerms()).thenReturn(termsResponses);
+
+    // when & then
+    mockMvc
+        .perform(get("/v1/auth/terms"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_GET_TERMS_SUCCESS.getCode()))
+        .andExpect(jsonPath("$.data").isArray())
+        .andExpect(jsonPath("$.data.length()").value(termsResponses.size()));
+  }
+
+  @Test
+  @DisplayName("약관이 없을 때 404 Not Found를 반환한다")
+  void whenGetTermsWithNoTerms_thenReturnsNotFound() throws Exception {
+    // given
+    when(authService.getTerms())
+        .thenThrow(new CustomException(ApiResponseCode.AUTH_TERMS_NOT_FOUND));
+
+    // when & then
+    mockMvc
+        .perform(get("/v1/auth/terms"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_TERMS_NOT_FOUND.getCode()));
+  }
+
+  /** logoutUser */
+  @Test
+  @DisplayName("로그아웃 시 200 OK를 반환한다")
+  void whenLogout_thenReturnsOk() throws Exception {
+    // given
+    String bearerToken = "Bearer " + TEST_JWT_TOKEN;
+
+    // when & then
+    mockMvc
+        .perform(post("/v1/auth/logout").header("Authorization", bearerToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_LOGOUT_SUCCESS.getCode()));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 토큰으로 로그아웃 시 401 Unauthorized를 반환한다")
+  void whenLogoutWithInvalidToken_thenReturnsUnauthorized() throws Exception {
+    // given
+    String invalidBearerToken = "Bearer " + INVALID_JWT_TOKEN;
+
+    // when & then
+    mockMvc
+        .perform(post("/v1/auth/logout").header("Authorization", invalidBearerToken))
+        .andExpect(status().isUnauthorized())
+        .andExpect(
+            jsonPath("$.code")
+                .value(ApiResponseCode.AUTH_ACCESS_TOKEN_INVALID_SIGNATURE.getCode()));
+  }
+
+  /** withdrawUser */
+  @Test
+  @DisplayName("회원탈퇴 시 200 OK를 반환한다")
+  void whenWithdraw_thenReturnsOk() throws Exception {
+    // given
+    String bearerToken = TEST_BEARER_TOKEN;
+
+    // when & then
+    mockMvc
+        .perform(delete("/v1/auth/withdraw").header("Authorization", bearerToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_WITHDRAW_USER_SUCCESS.getCode()));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 토큰으로 회원탈퇴 시 401 Unauthorized를 반환한다")
+  void whenWithdrawWithInvalidToken_thenReturnsUnauthorized() throws Exception {
+    // given
+    String invalidBearerToken = "Bearer " + INVALID_JWT_TOKEN;
+
+    // when & then
+    mockMvc
+        .perform(delete("/v1/auth/withdraw").header("Authorization", invalidBearerToken))
+        .andExpect(status().isUnauthorized())
+        .andExpect(
+            jsonPath("$.code")
+                .value(ApiResponseCode.AUTH_ACCESS_TOKEN_INVALID_SIGNATURE.getCode()));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자 회원탈퇴 시 404 Not Found를 반환한다")
+  void whenWithdrawNonExistentUser_thenReturnsNotFound() throws Exception {
+    // given
+    String bearerToken = TEST_BEARER_TOKEN;
+    doThrow(new CustomException(ApiResponseCode.AUTH_USER_NOT_FOUND))
+        .when(authService)
+        .withdrawUser();
+
+    // when & then
+    mockMvc
+        .perform(delete("/v1/auth/withdraw").header("Authorization", bearerToken))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(ApiResponseCode.AUTH_USER_NOT_FOUND.getCode()));
+  }
+}

--- a/src/test/java/org/bob/siungongsi/fixture/AuthFixture.java
+++ b/src/test/java/org/bob/siungongsi/fixture/AuthFixture.java
@@ -1,0 +1,94 @@
+package org.bob.siungongsi.fixture;
+
+import java.util.List;
+
+import org.bob.siungongsi.api.controller.dto.AuthRequest;
+import org.bob.siungongsi.api.controller.dto.AuthResponse;
+
+public class AuthFixture {
+
+  // 테스트용 소셜 ID 상수
+  public static final String TEST_SOCIAL_ID = "12345678";
+  public static final String TEST_SOCIAL_ID_2 = TEST_SOCIAL_ID + "1";
+
+  // 테스트용 토큰 상수
+  public static final String TEST_KAKAO_ACCESS_TOKEN = "test-kakao-access-token";
+  public static final String TEST_KAKAO_ACCESS_TOKEN_2 = TEST_KAKAO_ACCESS_TOKEN + "-2";
+  public static final String TEST_BEARER_TOKEN = "Bearer " + TEST_KAKAO_ACCESS_TOKEN;
+  public static final String TEST_BEARER_TOKEN_2 = "Bearer " + TEST_KAKAO_ACCESS_TOKEN_2;
+  public static final String TEST_JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test-jwt-token";
+  public static final String TEST_JWT_TOKEN_2 = TEST_JWT_TOKEN + "-2";
+  public static final String INVALID_JWT_TOKEN = "invalid.jwt.token";
+
+  // 약관 ID 상수
+  public static final Long REQUIRED_TERM_ID_1 = 1L;
+  public static final Long REQUIRED_TERM_ID_2 = 2L;
+  public static final Long OPTIONAL_TERM_ID = 3L;
+  public static final List<Long> ALL_REQUIRED_TERM_IDS =
+      List.of(REQUIRED_TERM_ID_1, REQUIRED_TERM_ID_2);
+  public static final List<Long> ALL_TERM_IDS =
+      List.of(REQUIRED_TERM_ID_1, REQUIRED_TERM_ID_2, OPTIONAL_TERM_ID);
+
+  public static class RegisterRequestBuilder {
+    private List<Long> agreedTermIds = ALL_TERM_IDS;
+
+    public RegisterRequestBuilder agreedTermIds(List<Long> agreedTermIds) {
+      this.agreedTermIds = agreedTermIds;
+      return this;
+    }
+
+    public AuthRequest.RegisterRequest build() {
+      return new AuthRequest.RegisterRequest(agreedTermIds);
+    }
+  }
+
+  public static RegisterRequestBuilder registerRequest() {
+    return new RegisterRequestBuilder();
+  }
+
+  public static class LoginSuccessResponseBuilder {
+    private String accessToken = TEST_JWT_TOKEN;
+    private boolean isUser = true;
+
+    public LoginSuccessResponseBuilder accessToken(String accessToken) {
+      this.accessToken = accessToken;
+      return this;
+    }
+
+    public LoginSuccessResponseBuilder isUser(boolean isUser) {
+      this.isUser = isUser;
+      return this;
+    }
+
+    public LoginSuccessResponseBuilder newUser() {
+      this.accessToken = null;
+      this.isUser = false;
+      return this;
+    }
+
+    public AuthResponse.LoginSuccessResponse build() {
+      return AuthResponse.LoginSuccessResponse.of(accessToken, isUser);
+    }
+  }
+
+  public static LoginSuccessResponseBuilder loginSuccessResponse() {
+    return new LoginSuccessResponseBuilder();
+  }
+
+  // 편의 메서드
+  public static AuthRequest.RegisterRequest createValidRegisterRequest() {
+    return registerRequest().build();
+  }
+
+  public static AuthRequest.RegisterRequest createRegisterRequestWithOnlyRequired() {
+    return registerRequest().agreedTermIds(ALL_REQUIRED_TERM_IDS).build();
+  }
+
+  public static AuthResponse.LoginSuccessResponse createExistingUserLoginResponse() {
+    return loginSuccessResponse().build();
+  }
+
+  public static AuthResponse.LoginSuccessResponse createNewUserLoginResponse() {
+    return loginSuccessResponse().newUser().build();
+  }
+}

--- a/src/test/java/org/bob/siungongsi/fixture/TermFixture.java
+++ b/src/test/java/org/bob/siungongsi/fixture/TermFixture.java
@@ -1,0 +1,129 @@
+package org.bob.siungongsi.fixture;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.bob.siungongsi.api.controller.dto.TermsResponse;
+import org.bob.siungongsi.common.domain.TermEntity;
+
+public class TermFixture {
+
+  // 약관 ID 상수
+  public static final Long TERM_ID_1 = 1L;
+  public static final Long TERM_ID_2 = 2L;
+  public static final Long TERM_ID_3 = 3L;
+
+  // 약관 제목 상수
+  public static final String REQUIRED_TERM_TITLE_1 = "서비스 이용약관";
+  public static final String REQUIRED_TERM_TITLE_2 = "개인정보 처리방침";
+  public static final String OPTIONAL_TERM_TITLE = "마케팅 수신 동의";
+
+  // 약관 내용 상수
+  public static final String TERM_CONTENT_1 = "서비스 이용약관 내용입니다.";
+  public static final String TERM_CONTENT_2 = "개인정보 처리방침 내용입니다.";
+  public static final String TERM_CONTENT_3 = "마케팅 수신 동의 내용입니다.";
+
+  // 약관 필수 여부 플래그
+  public static final Integer REQUIRED_FLAG = 1;
+  public static final Integer OPTIONAL_FLAG = 0;
+
+  /**
+   * TermEntity는 protected 생성자만 제공하고 setter 메서드가 없어 일반적인 방법으로 인스턴스 생성이 불가능합니다. 따라서 Mock 객체를 생성하고 필요한
+   * 필드값을 stub하여 반환합니다.
+   */
+  public static TermEntity createStubbedTermEntity(
+      Long id, String title, String content, Integer requiredFlag) {
+    TermEntity term = mock(TermEntity.class);
+    when(term.getId()).thenReturn(id);
+    when(term.getTitle()).thenReturn(title);
+    when(term.getContent()).thenReturn(content);
+    when(term.getRequiredFlag()).thenReturn(requiredFlag);
+    return term;
+  }
+
+  // 단건 생성 편의 메서드
+  public static TermEntity createRequiredTermEntity1() {
+    return createStubbedTermEntity(TERM_ID_1, REQUIRED_TERM_TITLE_1, TERM_CONTENT_1, REQUIRED_FLAG);
+  }
+
+  public static TermEntity createRequiredTermEntity2() {
+    return createStubbedTermEntity(TERM_ID_2, REQUIRED_TERM_TITLE_2, TERM_CONTENT_2, REQUIRED_FLAG);
+  }
+
+  public static TermEntity createOptionalTermEntity() {
+    return createStubbedTermEntity(TERM_ID_3, OPTIONAL_TERM_TITLE, TERM_CONTENT_3, OPTIONAL_FLAG);
+  }
+
+  // 다건 생성 편의 메서드
+  public static List<TermEntity> createAllTermEntities() {
+    return List.of(
+        createRequiredTermEntity1(), createRequiredTermEntity2(), createOptionalTermEntity());
+  }
+
+  public static List<TermEntity> createRequiredTermEntities() {
+    return List.of(createRequiredTermEntity1(), createRequiredTermEntity2());
+  }
+
+  public static List<TermEntity> createTermEntities(int size) {
+    return IntStream.range(0, size)
+        .mapToObj(
+            i ->
+                createStubbedTermEntity(
+                    (long) (i + 1), REQUIRED_TERM_TITLE_1 + i, TERM_CONTENT_1 + i, REQUIRED_FLAG))
+        .toList();
+  }
+
+  // TermsResponse Builder
+  public static class TermsResponseBuilder {
+    private Long termsId = TERM_ID_1;
+    private String termsTitle = REQUIRED_TERM_TITLE_1 + " (필수)";
+    private String termsContent = TERM_CONTENT_1;
+
+    public TermsResponseBuilder termsId(Long termsId) {
+      this.termsId = termsId;
+      return this;
+    }
+
+    public TermsResponseBuilder termsTitle(String termsTitle) {
+      this.termsTitle = termsTitle;
+      return this;
+    }
+
+    public TermsResponseBuilder termsContent(String termsContent) {
+      this.termsContent = termsContent;
+      return this;
+    }
+
+    public TermsResponse build() {
+      return TermsResponse.of(termsId, termsTitle, termsContent);
+    }
+  }
+
+  public static TermsResponseBuilder termsResponse() {
+    return new TermsResponseBuilder();
+  }
+
+  // TermsResponse 편의 메서드
+  public static TermsResponse createRequiredTermsResponse1() {
+    return termsResponse()
+        .termsId(TERM_ID_1)
+        .termsTitle(REQUIRED_TERM_TITLE_1 + " (필수)")
+        .termsContent(TERM_CONTENT_1)
+        .build();
+  }
+
+  public static TermsResponse createRequiredTermsResponse2() {
+    return termsResponse()
+        .termsId(TERM_ID_2)
+        .termsTitle(REQUIRED_TERM_TITLE_2 + " (필수)")
+        .termsContent(TERM_CONTENT_2)
+        .build();
+  }
+
+  public static List<TermsResponse> createAllTermsResponses() {
+    return List.of(createRequiredTermsResponse1(), createRequiredTermsResponse2());
+  }
+}

--- a/src/test/java/org/bob/siungongsi/fixture/UserFixture.java
+++ b/src/test/java/org/bob/siungongsi/fixture/UserFixture.java
@@ -1,0 +1,72 @@
+package org.bob.siungongsi.fixture;
+
+import static org.bob.siungongsi.fixture.AuthFixture.TEST_KAKAO_ACCESS_TOKEN;
+import static org.bob.siungongsi.fixture.AuthFixture.TEST_SOCIAL_ID;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.bob.siungongsi.common.domain.UserEntity;
+
+public class UserFixture {
+
+  // 테스트용 사용자 ID 상수
+  public static final Long TEST_USER_ID = 1L;
+  public static final Long TEST_USER_ID_2 = 2L;
+
+  public static class UserEntityBuilder {
+    private String socialId = TEST_SOCIAL_ID;
+    private String accessToken = TEST_KAKAO_ACCESS_TOKEN;
+    private String pushTokenId = null;
+    private boolean notiFlag = false;
+
+    public UserEntityBuilder socialId(String socialId) {
+      this.socialId = socialId;
+      return this;
+    }
+
+    public UserEntityBuilder accessToken(String accessToken) {
+      this.accessToken = accessToken;
+      return this;
+    }
+
+    public UserEntityBuilder pushTokenId(String pushTokenId) {
+      this.pushTokenId = pushTokenId;
+      return this;
+    }
+
+    public UserEntityBuilder notiFlag(boolean notiFlag) {
+      this.notiFlag = notiFlag;
+      return this;
+    }
+
+    public UserEntity build() {
+      UserEntity user = new UserEntity(socialId, accessToken);
+      if (pushTokenId != null) {
+        user.updatePushTokenId(pushTokenId);
+      }
+      user.updateNotiFlag(notiFlag);
+      return user;
+    }
+  }
+
+  public static UserEntityBuilder userEntity() {
+    return new UserEntityBuilder();
+  }
+
+  // 단건 생성 편의 메서드
+  public static UserEntity createDefaultUser() {
+    return userEntity().build();
+  }
+
+  public static UserEntity createUser(String socialId, String accessToken) {
+    return userEntity().socialId(socialId).accessToken(accessToken).build();
+  }
+
+  // 다건 생성 편의 메서드
+  public static List<UserEntity> createUsers(int size) {
+    return IntStream.range(0, size)
+        .mapToObj(i -> createUser(TEST_SOCIAL_ID + i, TEST_KAKAO_ACCESS_TOKEN + "-" + i))
+        .toList();
+  }
+}

--- a/src/test/java/org/bob/siungongsi/testhelper/config/SecurityConfigBeansForTest.java
+++ b/src/test/java/org/bob/siungongsi/testhelper/config/SecurityConfigBeansForTest.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 public class SecurityConfigBeansForTest {
 
-  // 해당 Mock을 임의로 stubbing 할 경우 기존 상태로 초기화 필수
+  // 해당 Mock을 임의로 stubbing 할 경우 기존 상태(본 메소드에서 정의한 stub)로 초기화 필수
   @Bean
   JwtProvider jwtProvider() {
     JwtProvider mock = mock(JwtProvider.class);
@@ -45,7 +45,7 @@ public class SecurityConfigBeansForTest {
     return new CorsProperties(List.of("*"));
   }
 
-  // 해당 Mock을 임의로 stubbing 할 경우 기존 상태로 초기화 필수
+  // 해당 Mock을 임의로 stubbing 할 경우 기존 상태(본 메소드에서 정의한 stub)로 초기화 필수
   @Bean
   AuthBlackListService authBlackListService() {
     AuthBlackListService mock = mock(AuthBlackListService.class);

--- a/src/test/java/org/bob/siungongsi/testhelper/config/SecurityConfigBeansForTest.java
+++ b/src/test/java/org/bob/siungongsi/testhelper/config/SecurityConfigBeansForTest.java
@@ -1,0 +1,59 @@
+package org.bob.siungongsi.testhelper.config;
+
+import static org.bob.siungongsi.fixture.AuthFixture.INVALID_JWT_TOKEN;
+import static org.bob.siungongsi.fixture.AuthFixture.TEST_JWT_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.bob.siungongsi.api.config.CorsProperties;
+import org.bob.siungongsi.api.service.AuthBlackListService;
+import org.bob.siungongsi.common.dto.ApiResponseCode;
+import org.bob.siungongsi.common.exception.CustomException;
+import org.bob.siungongsi.common.security.JwtProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("test")
+@Configuration
+public class SecurityConfigBeansForTest {
+
+  // 해당 Mock을 임의로 stubbing 할 경우 기존 상태로 초기화 필수
+  @Bean
+  JwtProvider jwtProvider() {
+    JwtProvider mock = mock(JwtProvider.class);
+    when(mock.createJwtToken(anyString())).thenReturn(TEST_JWT_TOKEN);
+    when(mock.createJwtToken(anyString(), anyLong())).thenReturn(TEST_JWT_TOKEN);
+
+    when(mock.validateJwtToken(anyString())).thenReturn(1L);
+    when(mock.validateJwtToken(eq(INVALID_JWT_TOKEN)))
+        .thenThrow(new CustomException(ApiResponseCode.AUTH_ACCESS_TOKEN_INVALID_SIGNATURE));
+
+    when(mock.getRemainingExpirationTime(anyString())).thenReturn(3000L);
+    return mock;
+  }
+
+  @Bean
+  CorsProperties corsProperties() {
+    return new CorsProperties(List.of("*"));
+  }
+
+  // 해당 Mock을 임의로 stubbing 할 경우 기존 상태로 초기화 필수
+  @Bean
+  AuthBlackListService authBlackListService() {
+    AuthBlackListService mock = mock(AuthBlackListService.class);
+    doNothing().when(mock).setBlackList(anyString(), any(), eq(300000L));
+
+    when(mock.hasKeyBlackList(anyString())).thenReturn(false);
+
+    when(mock.deleteBlackList(anyString())).thenReturn(true);
+    return mock;
+  }
+}


### PR DESCRIPTION
### Description

authController 테스트를 작성해 상위 브랜치에 병합한다.


### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. Auth, Term, User 테스트 픽스쳐 작성
2. 테스트 시 SecurityConfig 에 주입될 Mock Bean 작성
3. AuthController 테스트 작성


### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

- 매직 상수나 테스트 엔티티 생성 등은 fixture로 따로 관리합니다. fixture 도메인 간 순환구조가 생기지 않게 조심해야합니다.
- WebMvcTest에서 SecurityConfig를 강하게 의존하고 있어 테스트용 Mock Bean을 주입해 풀었습니다.
- 테스트 코드는 요구사항을 충족하는 정도로 상태검사만 최소한으로 검사했습니다. 최소한으로 빠르게 작성하고 빠르게 읽을 수 있는게 유닛 테스트의 장점이라 생각해 정했습니다.